### PR TITLE
feat: Charge les fichiers JSON depuis les assets et non plus depuis l…

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:mobaitec_decision_making/screens/dashboard/dashboard.dart';
 import 'package:mobaitec_decision_making/utils/app_routes.dart';
 import 'package:mobaitec_decision_making/utils/colors.dart';
 import 'package:desktop_window/desktop_window.dart';
+import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:provider/provider.dart';
 import 'services/keycloak/keycloak_provider.dart';
 import 'package:mobaitec_decision_making/services/theme/theme_provider.dart';
@@ -13,7 +14,9 @@ import 'package:mobaitec_decision_making/services/data/local_data_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Hive.initFlutter();
+  final dir = await path_provider.getApplicationSupportDirectory();
+  Hive.init(dir.path);
+
 
   // Initialiser les boîtes Hive pour le cache
   await Hive.openBox('navision_cache');

--- a/frontend/lib/services/data/local_data_service.dart
+++ b/frontend/lib/services/data/local_data_service.dart
@@ -79,21 +79,17 @@ class LocalDataService {
   }
 
   /// Charge un fichier JSON depuis le système de fichiers
+
   static Future<Map<String, dynamic>?> _loadJsonFile(String path) async {
     try {
-      final file = File(path);
-      if (await file.exists()) {
-        final jsonString = await file.readAsString();
-        return json.decode(jsonString) as Map<String, dynamic>;
-      } else {
-        print('⚠️ Fichier non trouvé: $path');
-        return null;
-      }
+      final contents = await rootBundle.loadString(path);
+      return json.decode(contents) as Map<String, dynamic>;
     } catch (e) {
-      print('⚠️ Erreur lors de la lecture du fichier: $path - $e');
+      print('❌ Erreur chargement JSON depuis assets: $path - $e');
       return null;
     }
   }
+
 
   /// Obtient la liste des sociétés disponibles
   static List<String> getAvailableSocietes() {

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   hive_flutter: ^1.1.0
   intl: ^0.19.0
   parse_server_sdk_flutter: ^8.0.0
+  path_provider: ^2.1.5
   provider: ^6.0.5
   shared_preferences: ^2.0.15
   shimmer: ^3.0.0
@@ -32,3 +33,6 @@ flutter:
   assets:
     - assets/mobaitec-logo.png
     - assets/keycloak.png
+    - lib/data/rsp-bgs/
+    - lib/data/rsp-neg/
+    - lib/data/rsp-sb/


### PR DESCRIPTION
…e système de fichiers

Modifie le chargement des fichiers JSON pour utiliser les assets de l'application plutôt que le système de fichiers local. Ajoute les répertoires de données JSON aux assets dans `pubspec.yaml`. Met à jour l'initialisation de Hive pour utiliser le répertoire de support de l'application.